### PR TITLE
more error logging, and error message string constants

### DIFF
--- a/src/resolvers/DiscoveryQueueResolver.js
+++ b/src/resolvers/DiscoveryQueueResolver.js
@@ -1,8 +1,10 @@
 import { User } from '../models/UserModel';
 import { DiscoveryQueue, DiscoveryItem } from '../models/DiscoveryQueueModel';
 import { updateDiscoveryForUserById } from '../discovery/DiscoverProfile';
+import { FORCE_FEED_UPDATE_ERROR, FORCE_FEED_UPDATE_SUCCESS } from './ResolverErrorStrings';
 
 const debug = require('debug')('dev:DiscoveryQueueResolver');
+const errorLog = require('debug')('error:DiscoveryQueueResolver');
 
 
 export const resolvers = {
@@ -26,15 +28,16 @@ export const resolvers = {
         try {
           await updateDiscoveryForUserById({ user_id });
         } catch (e) {
+          errorLog(`An error occurred: ${e}`);
           return {
             success: false,
-            message: `An error occurred: ${e}`,
+            message: FORCE_FEED_UPDATE_ERROR,
           };
         }
       }
       return {
         success: true,
-        message: 'Successfully forced update to feed.',
+        message: FORCE_FEED_UPDATE_SUCCESS,
       };
     },
   },

--- a/src/resolvers/ResolverErrorStrings.js
+++ b/src/resolvers/ResolverErrorStrings.js
@@ -1,0 +1,18 @@
+export const GET_USER_ERROR = 'Failed to find user.';
+export const CREATE_USER_ERROR = 'Failed to initialize user.';
+export const UPDATE_USER_PHOTOS_ERROR = 'Failed to update photos.';
+export const CREATE_DETACHED_PROFILE_ERROR = 'Failed to create profile.';
+export const GET_DETACHED_PROFILE_ERROR = 'Failed to find profile.';
+export const WRONG_CREATOR_ERROR = 'Matchmaker did not create profile for this user.';
+export const CANT_ENDORSE_YOURSELF = 'Can\'t create a profile for yourself.';
+export const ALREADY_MADE_PROFILE = 'Already made a profile for this person.';
+export const APPROVE_PROFILE_ERROR = 'Couldn\'t approve this profile.';
+export const FORCE_FEED_UPDATE_ERROR = 'Couldn\'t update feed.';
+export const SEND_MATCH_REQUEST_ERROR = 'Couldn\'t send match request.';
+export const VIEW_MATCH_REQUEST_ERROR = 'Couldn\'t view match request.';
+export const MATCH_ALREADY_DECIDED = 'This request has already been accepted or rejected.';
+export const ACCEPT_MATCH_REQUEST_ERROR = 'Couldn\'t accept match request.';
+export const REJECT_MATCH_REQUEST_ERROR = 'Couldn\'t perform action on match request.';
+export const UNMATCH_ERROR = 'Couldn\'t perform action on match.';
+
+export const FORCE_FEED_UPDATE_SUCCESS = 'Updated feed successfully.';

--- a/src/resolvers/UserResolver.js
+++ b/src/resolvers/UserResolver.js
@@ -5,9 +5,15 @@ import { User, createUserObject } from '../models/UserModel';
 import { UserProfile } from '../models/UserProfileModel';
 import { Match } from '../models/MatchModel';
 import { authenticateUser } from '../FirebaseManager';
+import {
+  CREATE_USER_ERROR,
+  GET_USER_ERROR,
+  UPDATE_USER_PHOTOS_ERROR,
+} from './ResolverErrorStrings';
 
 const mongoose = require('mongoose');
 const debug = require('debug')('dev:UserResolvers');
+const errorLog = require('debug')('error:UserResolver');
 const functionCallConsole = require('debug')('dev:FunctionCalls');
 
 
@@ -43,20 +49,19 @@ export const resolvers = {
           if (user) {
             resolve({
               success: true,
-              message: 'Successfully fetched',
               user,
             });
           } else {
             resolve({
               success: false,
-              message: 'Failed to fetch user',
+              message: GET_USER_ERROR,
             });
           }
         })
-        .catch((err) => {
+        .catch(() => {
           resolve({
             success: false,
-            message: err.toString(),
+            message: GET_USER_ERROR,
           });
         }));
     },
@@ -115,9 +120,9 @@ export const resolvers = {
           if (userObject instanceof Error
             || discoveryQueueObject instanceof Error) {
             debug('error occurred while creating user');
-            let message = '';
+            let errorMessage = '';
             if (userObject instanceof Error) {
-              message += userObject.toString();
+              errorMessage += userObject.toString();
             } else {
               userObject.remove((err) => {
                 if (err) {
@@ -128,7 +133,7 @@ export const resolvers = {
               });
             }
             if (discoveryQueueObject instanceof Error) {
-              message += discoveryQueueObject.toString();
+              errorMessage += discoveryQueueObject.toString();
             } else {
               discoveryQueueObject.remove((err) => {
                 if (err) {
@@ -138,9 +143,10 @@ export const resolvers = {
                 }
               });
             }
+            errorLog(errorMessage);
             return {
               success: false,
-              message,
+              message: CREATE_USER_ERROR,
             };
           }
           return {
@@ -158,7 +164,7 @@ export const resolvers = {
       if (!user) {
         return {
           success: false,
-          message: `User with id ${user_id} does not exist`,
+          message: GET_USER_ERROR,
         };
       }
       const toAddToImageBank = [];
@@ -200,9 +206,9 @@ export const resolvers = {
           success: true,
           user: res,
         }))
-        .catch(err => ({
+        .catch(() => ({
           success: false,
-          message: `Failed to update user with new photos: ${err}`,
+          message: UPDATE_USER_PHOTOS_ERROR,
         }));
     },
   }

--- a/src/start.js
+++ b/src/start.js
@@ -57,7 +57,7 @@ import {
 const { ApolloServer } = require('apollo-server-express');
 
 const debug = require('debug')('dev:Start');
-const errorLog = require('debug')('dev:error:Start');
+const errorLog = require('debug')('error:Start');
 const prodConsole = require('debug')('prod:Start');
 
 

--- a/src/tests/ImageUploads.js
+++ b/src/tests/ImageUploads.js
@@ -1,5 +1,5 @@
 const debug = require('debug')('dev:tests:ImageUpload');
-const errorLog = require('debug')('dev:error:ImageUpload');
+const errorLog = require('debug')('error:ImageUpload');
 const fs = require('fs');
 const path = require('path');
 const request = require('request');


### PR DESCRIPTION
 - Log errors to `error:*` rather than `dev:error:*`
 - In cases where GraphQL server returns a failure result, the message returned with it is now taken from constants defined in `ResolverErrorStrings`
 - In cases where we we used to pass the error to the client in the GraphQL response, we instead log to `error:*`