### PR TITLE
handle already matched error

### DIFF
--- a/src/models/UserModel.js
+++ b/src/models/UserModel.js
@@ -2,6 +2,7 @@ import { MatchingDemographicsSchema, MatchingPreferencesSchema } from './Matchin
 import { ImageContainerSchema } from './ImageSchemas';
 import { EdgeSummarySchema } from './MatchModel';
 import { EndorsementEdgeSchema } from './UserProfileModel';
+import { USERS_ALREADY_MATCHED_ERROR } from '../resolvers/ResolverErrorStrings';
 
 const mongoose = require('mongoose');
 
@@ -334,7 +335,9 @@ export const receiveRequest = (me, otherUser, match_id) => {
     edgeSummary => (edgeSummary.otherUser_id.toString() === otherUser._id.toString()),
   );
   if (alreadyExists !== undefined) {
-    throw new Error(`edge between ${me._id} and ${otherUser._id} already exists`);
+    return Promise.reject(
+      new Error(USERS_ALREADY_MATCHED_ERROR),
+    );
   }
   me.edgeSummaries.push({
     otherUser_id: otherUser._id,
@@ -349,7 +352,9 @@ export const sendRequest = (me, otherUser, match_id) => {
     edgeSummary => (edgeSummary.otherUser_id.toString() === otherUser._id.toString()),
   );
   if (alreadyExists !== undefined) {
-    throw new Error(`edge between ${me._id} and ${otherUser._id} already exists`);
+    return Promise.reject(
+      new Error(USERS_ALREADY_MATCHED_ERROR),
+    );
   }
   me.edgeSummaries.push({
     otherUser_id: otherUser._id,

--- a/src/resolvers/DetachedProfileResolver.js
+++ b/src/resolvers/DetachedProfileResolver.js
@@ -319,6 +319,7 @@ export const resolvers = {
     approveNewDetachedProfile: async (_source, { user_id, detachedProfile_id, creatorUser_id }) => {
       functionCallConsole('Approve Profile Called');
 
+      // TODO: Handle error
       const { user, detachedProfile, creator } = await getAndValidateUsersAndDetachedProfileObjects(
         {
           user_id,

--- a/src/resolvers/ResolverErrorStrings.js
+++ b/src/resolvers/ResolverErrorStrings.js
@@ -12,6 +12,7 @@ export const ALREADY_MADE_PROFILE = 'Already made a profile for this person.';
 export const APPROVE_PROFILE_ERROR = 'Couldn\'t approve this profile.';
 export const FORCE_FEED_UPDATE_ERROR = 'Couldn\'t update feed.';
 export const SEND_MATCH_REQUEST_ERROR = 'Couldn\'t send match request.';
+export const USERS_ALREADY_MATCHED_ERROR = 'These users have already been Peared!';
 export const ACCEPT_MATCH_REQUEST_ERROR = 'Couldn\'t accept match request.';
 export const REJECT_MATCH_REQUEST_ERROR = 'Couldn\'t perform action on match request.';
 export const UNMATCH_ERROR = 'Couldn\'t perform action on match.';


### PR DESCRIPTION
returns a readable user message instead of a graphql error when you try to pear someone with someone they've already been peared with

resolves #57 