### PR TITLE
fix

### DIFF
--- a/src/resolvers/DiscoveryQueueResolvers/SkipDiscoveryItem.js
+++ b/src/resolvers/DiscoveryQueueResolvers/SkipDiscoveryItem.js
@@ -35,12 +35,26 @@ export const skipDiscoveryItemResolver = async ({
     };
   }
 
+  let skippedUser_id = null;
+  for (const discoveryItem of discoveryQueue.currentDiscoveryItems) {
+    if (discoveryItem._id.toString() === discoveryItem_id) {
+      skippedUser_id = discoveryItem.user_id.toString();
+      break;
+    }
+  }
+  if (!skippedUser_id) {
+    errorLog(`discovery item ${discoveryItem_id} for user ${user_id} not found`);
+    return {
+      success: false,
+      message: SKIP_DISCOVERY_ITEM_ERROR,
+    };
+  }
   discoveryQueue.currentDiscoveryItems = discoveryQueue.currentDiscoveryItems
     .filter(discoveryItem => discoveryItem._id.toString() !== discoveryItem_id);
   if (!discoveryQueue.skippedUser_ids) {
     discoveryQueue.skippedUser_ids = [];
   }
-  discoveryQueue.skippedUser_ids.push(user_id);
+  discoveryQueue.skippedUser_ids.push(skippedUser_id);
   const res = await discoveryQueue.save().catch(err => err);
   if (res instanceof Error) {
     errorLog(res.toString());

--- a/src/resolvers/MatchingResolvers/CreateNewMatch.js
+++ b/src/resolvers/MatchingResolvers/CreateNewMatch.js
@@ -100,7 +100,7 @@ export const createNewMatchResolver = async ({
     .exec()
     .catch(() => null);
   const [sentByDiscovery, sentForDiscovery, receivedByDiscovery] = await Promise
-    .all([sentForDiscoveryPromise, sentByDiscoveryPromise, receivedByDiscoveryPromise]);
+    .all([sentByDiscoveryPromise, sentForDiscoveryPromise, receivedByDiscoveryPromise]);
   if (!sentByDiscovery) {
     errorLog(`Couldn't find discovery queue for user with id ${sentByUser_id}`);
     return {


### PR DESCRIPTION
two bugs:
1. instead of adding the _id of the user you skipped into your discovery queue, i was adding add your own user _id
2. switched two references in CreateNewMatch (discovery queues of sentFor and sentBy). this was a no-op for the current version of discovery, but is not a no-op in the new discovery schema. thank u tests!!